### PR TITLE
Changed config for multiple island types, added single block island

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ buildscript {
     }
 }
 
+
+
 apply plugin: 'forge'
 
 version = "1.3.1"
@@ -26,6 +28,9 @@ minecraft {
     runDir = "run"
 }
 
+dependencies {
+    compile files("lib/Botania r1.8-249.jar")
+}
 processResources
 {
     from(sourceSets.main.resources.srcDirs) {

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,6 @@ minecraft {
     runDir = "run"
 }
 
-dependencies {
-    compile files("lib/Botania r1.8-249.jar")
-}
 processResources
 {
     from(sourceSets.main.resources.srcDirs) {

--- a/src/main/java/com/cricketcraft/ftbisland/FTBIslands.java
+++ b/src/main/java/com/cricketcraft/ftbisland/FTBIslands.java
@@ -157,7 +157,9 @@ public class FTBIslands {
                 	FTBIslands.islandType = config.getString("Island Type", "misc", "tree", "Set this to the type of platform you want:\n" +
     	            		"  'grass'     A single grass block\n" +
     	            		"  'tree'      A small oak tree on a grass block (Standard SkyFactory Island Start)\n" +
-    	            		"  'platform'  A 3x3 platform with a chest.");
+    	            		"  'platform'  A 3x3 platform with a chest." +
+                			"  'GoG'       A Garden of Glass island from Botania.");
+
                 	config.moveProperty("misc", "Sky Factory", "forRemoval");
                 	config.moveProperty("misc", "Platform", "forRemoval");
                 	config.removeCategory(config.getCategory("forRemoval"));
@@ -167,8 +169,24 @@ public class FTBIslands {
 	            FTBIslands.islandType = config.getString("Island Type", "misc", "platform", "Set this to the type of platform you want:\n" +
 	            		"  'grass'     A single grass block\n" +
 	            		"  'tree'      A small oak tree on a grass block (Standard SkyFactory Island Start)\n" +
-	            		"  'platform'  A 3x3 platform with a chest.");
-	            if (!(FTBIslands.islandType.equalsIgnoreCase("grass") || FTBIslands.islandType.equalsIgnoreCase("tree") || FTBIslands.islandType.equalsIgnoreCase("platform"))) {
+	            		"  'platform'  A 3x3 platform with a chest." +
+	            		"  'GoG'       A Garden of Glass island from Botania.");
+
+	            // list of valid types, for making new island types easier to add.
+	            ArrayList<String> validTypes = new ArrayList<String>();
+	            validTypes.add("grass");
+	            validTypes.add("tree");
+	            validTypes.add("platform");
+	            validTypes.add("GoG");
+	            
+	            boolean valid = false;
+	            for (String type : validTypes) {
+	            	if (FTBIslands.islandType.equalsIgnoreCase(type)) {
+	            		valid = true;
+	            		break;
+	            	}
+	            }
+	            if (!valid) {
             		logger.warn("Invalid config for Island Type, using 'platform' as default");
             		FTBIslands.islandType = "platform";
 	            }

--- a/src/main/java/com/cricketcraft/ftbisland/FTBIslands.java
+++ b/src/main/java/com/cricketcraft/ftbisland/FTBIslands.java
@@ -41,8 +41,7 @@ public class FTBIslands {
     public static int maxIslands;
     public static File islands;
     public static Logger logger;
-    public static boolean skyFactory;
-    public static boolean platform;
+    public static String islandType;
     private static File oldIslands;
     private static File directory;
 
@@ -122,6 +121,7 @@ public class FTBIslands {
                 e.printStackTrace();
             }
         }
+        br.close();
     }
 
     public static void saveIslands(HashMap<String, IslandCreator.IslandPos> map) throws IOException {
@@ -148,10 +148,31 @@ public class FTBIslands {
 
         private static void loadConfig() {
             FTBIslands.maxIslands = config.getInt("Max Islands", "misc", 100, 1, 1000, "The maximum amount of islands that can be created. This number will be multiplied by four." +
-                    " Be careful with high numbers.");
-            FTBIslands.skyFactory = config.getBoolean("Sky Factory", "misc", false, "Set this to true if you are playing on Sky Factory.");
-            FTBIslands.platform = config.getBoolean("Platform", "misc", false, "Set to true if you want to start on a 3x3 platform, or false for a tree.");
-
+            		" Be careful with high numbers.");
+            // Convert old configs to new config format
+            if (!config.hasKey("misc", "Island Type")) {
+                boolean skyFactory = config.getBoolean("Sky Factory", "misc", false, "Set this to true if you are playing on Sky Factory.");
+                boolean platform = config.getBoolean("Platform", "misc", false, "Set to true if you want to start on a 3x3 platform, or false for a tree.");
+                if (skyFactory || !platform) {
+                	FTBIslands.islandType = config.getString("Island Type", "misc", "tree", "Set this to the type of platform you want:\n" +
+    	            		"  'grass'     A single grass block\n" +
+    	            		"  'tree'      A small oak tree on a grass block (Standard SkyFactory Island Start)\n" +
+    	            		"  'platform'  A 3x3 platform with a chest.");
+                	config.moveProperty("misc", "Sky Factory", "forRemoval");
+                	config.moveProperty("misc", "Platform", "forRemoval");
+                	config.removeCategory(config.getCategory("forRemoval"));
+                }
+            // Otherwise get Island Type from config, check for proper config string, set to default if user has bad configs
+            } else {
+	            FTBIslands.islandType = config.getString("Island Type", "misc", "platform", "Set this to the type of platform you want:\n" +
+	            		"  'grass'     A single grass block\n" +
+	            		"  'tree'      A small oak tree on a grass block (Standard SkyFactory Island Start)\n" +
+	            		"  'platform'  A 3x3 platform with a chest.");
+	            if (!(FTBIslands.islandType.equalsIgnoreCase("grass") || FTBIslands.islandType.equalsIgnoreCase("tree") || FTBIslands.islandType.equalsIgnoreCase("platform"))) {
+            		logger.warn("Invalid config for Island Type, using 'platform' as default");
+            		FTBIslands.islandType = "platform";
+	            }
+            }
             if (config.hasChanged())
                 config.save();
         }

--- a/src/main/java/com/cricketcraft/ftbisland/FTBIslands.java
+++ b/src/main/java/com/cricketcraft/ftbisland/FTBIslands.java
@@ -149,7 +149,7 @@ public class FTBIslands {
         private static void loadConfig() {
             FTBIslands.maxIslands = config.getInt("Max Islands", "misc", 100, 1, 1000, "The maximum amount of islands that can be created. This number will be multiplied by four." +
             		" Be careful with high numbers.");
-            // Convert old configs to new config format
+            // Convert old configs properties to new config property
             if (!config.hasKey("misc", "Island Type")) {
                 boolean skyFactory = config.getBoolean("Sky Factory", "misc", false, "Set this to true if you are playing on Sky Factory.");
                 boolean platform = config.getBoolean("Platform", "misc", false, "Set to true if you want to start on a 3x3 platform, or false for a tree.");
@@ -157,8 +157,8 @@ public class FTBIslands {
                 	FTBIslands.islandType = config.getString("Island Type", "misc", "tree", "Set this to the type of platform you want:\n" +
     	            		"  'grass'     A single grass block\n" +
     	            		"  'tree'      A small oak tree on a grass block (Standard SkyFactory Island Start)\n" +
-    	            		"  'platform'  A 3x3 platform with a chest." +
-                			"  'GoG'       A Garden of Glass island from Botania.");
+    	            		"  'platform'  A 3x3 platform with a chest\n" +
+                			"  'GoG'       Similar to Garden of Glass island from Botania");
 
                 	config.moveProperty("misc", "Sky Factory", "forRemoval");
                 	config.moveProperty("misc", "Platform", "forRemoval");
@@ -169,8 +169,8 @@ public class FTBIslands {
 	            FTBIslands.islandType = config.getString("Island Type", "misc", "platform", "Set this to the type of platform you want:\n" +
 	            		"  'grass'     A single grass block\n" +
 	            		"  'tree'      A small oak tree on a grass block (Standard SkyFactory Island Start)\n" +
-	            		"  'platform'  A 3x3 platform with a chest." +
-	            		"  'GoG'       A Garden of Glass island from Botania.");
+	            		"  'platform'  A 3x3 platform with a chest\n" +
+	            		"  'GoG'       Similar to Garden of Glass island from Botania");
 
 	            // list of valid types, for making new island types easier to add.
 	            ArrayList<String> validTypes = new ArrayList<String>();

--- a/src/main/java/com/cricketcraft/ftbisland/IslandCreator.java
+++ b/src/main/java/com/cricketcraft/ftbisland/IslandCreator.java
@@ -1,10 +1,12 @@
 package com.cricketcraft.ftbisland;
 
+import java.awt.Color;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -17,7 +19,7 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
 import net.minecraft.tileentity.TileEntitySign;
 
-
+import vazkii.botania.common.world.SkyblockWorldEvents;
 import net.minecraftforge.common.util.ForgeDirection;
 
 public class IslandCreator {
@@ -70,8 +72,20 @@ public class IslandCreator {
         		world.setBlock(x, y, z, Blocks.grass);
 	 			world.setBlock(x, y + 1, z, Blocks.standing_sign, 6 , 3);
 	 			((TileEntitySign) world.getTileEntity(x, y + 1, z)).signText[0] = "You get it yet?";
+	 		// Creates a Garden of Glass island type
+            } else if (FTBIslands.islandType.equalsIgnoreCase("GoG")) {
+        		if (Loader.isModLoaded("Botania")) {
+        			SkyblockWorldEvents.createSkyblock(world,  x,  y -1,  z);
+        		} else {
+                	for(int i = 0; i < 3; i++)
+            			for(int j = 0; j < 4; j++)
+            				for(int k = 0; k < 3; k++)
+            					world.setBlock(x - 1 + i, y - j, z - 1 + k, j == 0 ? Blocks.grass : Blocks.dirt);
+            		world.setBlock(x - 1, y - 1, z, Blocks.flowing_water);
+        		}
+            	
             // Creates a 3x3 platform of dirt with a chest on it, defaults to this if no other types are selected.
-            } else {
+        	} else {
                 for (int c = 0; c < 3; c++) {
                     for (int d = 0; d < 3; d++) {
                         world.setBlock(x + c, y, z + d, Blocks.dirt);

--- a/src/main/java/com/cricketcraft/ftbisland/IslandCreator.java
+++ b/src/main/java/com/cricketcraft/ftbisland/IslandCreator.java
@@ -15,6 +15,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
+import net.minecraft.tileentity.TileEntitySign;
+
 
 import net.minecraftforge.common.util.ForgeDirection;
 
@@ -37,8 +39,9 @@ public class IslandCreator {
     public static boolean spawnIslandAt(World world, int x, int y, int z, String playerName, EntityPlayer player) {
         reloadIslands();
         if (!islandLocations.containsKey(playerName)) {
-            if (FTBIslands.skyFactory) {
-                world.setBlock(x, y, z, Blocks.dirt);
+        	// Creates a standard Sky Factory island: Small Oak Tree on a block of Grass
+            if (FTBIslands.islandType.equalsIgnoreCase("tree")) {
+                world.setBlock(x, y, z, Blocks.grass);
                 for(int c = -3; c < 2; c++ ) {
                     for(int d = -3; d < 2; d++) {
                         for(int e = 3; e < 5; e++) {
@@ -62,6 +65,12 @@ public class IslandCreator {
                 for(int c = 0; c < 5; c++ ) {
                     world.setBlock(x, y + c + 1, z, Blocks.log);
                 }
+            // Creates an island of a single block of grass with a sign -- #GrassBlockChallenge from Darkosto
+            } else if (FTBIslands.islandType.equalsIgnoreCase("grass")) {
+        		world.setBlock(x, y, z, Blocks.grass);
+	 			world.setBlock(x, y + 1, z, Blocks.standing_sign, 6 , 3);
+	 			((TileEntitySign) world.getTileEntity(x, y + 1, z)).signText[0] = "You get it yet?";
+            // Creates a 3x3 platform of dirt with a chest on it, defaults to this if no other types are selected.
             } else {
                 for (int c = 0; c < 3; c++) {
                     for (int d = 0; d < 3; d++) {

--- a/src/main/java/com/cricketcraft/ftbisland/IslandCreator.java
+++ b/src/main/java/com/cricketcraft/ftbisland/IslandCreator.java
@@ -19,7 +19,6 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
 import net.minecraft.tileentity.TileEntitySign;
 
-import vazkii.botania.common.world.SkyblockWorldEvents;
 import net.minecraftforge.common.util.ForgeDirection;
 
 public class IslandCreator {
@@ -41,6 +40,7 @@ public class IslandCreator {
     public static boolean spawnIslandAt(World world, int x, int y, int z, String playerName, EntityPlayer player) {
         reloadIslands();
         if (!islandLocations.containsKey(playerName)) {
+        	
         	// Creates a standard Sky Factory island: Small Oak Tree on a block of Grass
             if (FTBIslands.islandType.equalsIgnoreCase("tree")) {
                 world.setBlock(x, y, z, Blocks.grass);
@@ -67,21 +67,53 @@ public class IslandCreator {
                 for(int c = 0; c < 5; c++ ) {
                     world.setBlock(x, y + c + 1, z, Blocks.log);
                 }
+                
             // Creates an island of a single block of grass with a sign -- #GrassBlockChallenge from Darkosto
             } else if (FTBIslands.islandType.equalsIgnoreCase("grass")) {
         		world.setBlock(x, y, z, Blocks.grass);
 	 			world.setBlock(x, y + 1, z, Blocks.standing_sign, 6 , 3);
 	 			((TileEntitySign) world.getTileEntity(x, y + 1, z)).signText[0] = "You get it yet?";
+	 			
 	 		// Creates a Garden of Glass island type
+	 		// This island's code is largely adapted from Botania, owned by Vazkii at: 
+	 		// https://github.com/Vazkii/Botania/blob/master/src/main/java/vazkii/botania/common/world/SkyblockWorldEvents.java#L164,
+	 		// I can't figure out any other way to accomplish creating the GoG island other than using that code to create it 
+	 		// (at least not without making it horribly coded).
+	 		// This notice should suffice to meet the Botania license as long as FTB-Islands stays open source.	
             } else if (FTBIslands.islandType.equalsIgnoreCase("GoG")) {
+            	for(int i = 0; i < 3; i++)
+        			for(int j = 0; j < 4; j++)
+        				for(int k = 0; k < 3; k++)
+        					world.setBlock(x - 1 + i, y - j, z - 1 + k, j == 0 ? Blocks.grass : Blocks.dirt);
+        		world.setBlock(x - 1, y - 1, z, Blocks.flowing_water);
+        		
+        		int[][] roots = new int[][] {
+        				{ -1, -2, -1 },
+        				{ -1, -4, -2 },
+        				{ -2, -3, -1 },
+        				{ -2, -3, -2 },
+        				{  1, -3, -1 },
+        				{  1, -4, -1 },
+        				{  2, -4, -1 },
+        				{  2, -4,  0 }, 
+        				{  3, -5,  0 },
+        				{  0, -2,  1 },
+        				{  0, -3,  2 },
+        				{  0, -4,  3 },
+        				{  1, -4,  3 },
+        				{  1, -5,  2 },
+        				{  1, -2,  0 },
+	        		};
+	        		
         		if (Loader.isModLoaded("Botania")) {
-        			SkyblockWorldEvents.createSkyblock(world,  x,  y -1,  z);
+        			world.setBlock(x + 1, y + 3, z + 1, GameRegistry.findBlock("Botania", "manaFlame"));
+	        		world.setBlock(x, y - 3, z, Blocks.bedrock);
+
+	        		for (int[] pos : roots)
+	        			world.setBlock(x + pos[0], y + pos[1], z + pos[2], GameRegistry.findBlock("Botania", "root"));
         		} else {
-                	for(int i = 0; i < 3; i++)
-            			for(int j = 0; j < 4; j++)
-            				for(int k = 0; k < 3; k++)
-            					world.setBlock(x - 1 + i, y - j, z - 1 + k, j == 0 ? Blocks.grass : Blocks.dirt);
-            		world.setBlock(x - 1, y - 1, z, Blocks.flowing_water);
+        			for (int[] pos: roots)
+	        			world.setBlock(x + pos[0], y + pos[1], z + pos[2], Blocks.log, 12, 3);
         		}
             	
             // Creates a 3x3 platform of dirt with a chest on it, defaults to this if no other types are selected.

--- a/src/main/java/com/cricketcraft/ftbisland/IslandUtils.java
+++ b/src/main/java/com/cricketcraft/ftbisland/IslandUtils.java
@@ -45,8 +45,10 @@ public class IslandUtils {
                 if (player.dimension != 0) {
                     player.travelToDimension(0);
                 }
-                int yNumber = FTBIslands.skyFactory ? 6 : 2;
-                player.setPositionAndUpdate(pos.getX() + 1.5, pos.getY() + yNumber, pos.getZ() + 1.5);
+                // Make sure you land in the right place, and don't fall off
+                int yNumber = FTBIslands.islandType.equalsIgnoreCase("tree") ? 6 : 2;
+                double vNumber = FTBIslands.islandType.equalsIgnoreCase("grass") ? 0.5 : 1.5;
+                player.setPositionAndUpdate(pos.getX() + vNumber, pos.getY() + yNumber, pos.getZ() + vNumber);
             } else {
                 player.addChatComponentMessage(new ChatComponentText("Island does not exist!"));
             }

--- a/src/main/java/com/cricketcraft/ftbisland/commands/JoinIslandCommand.java
+++ b/src/main/java/com/cricketcraft/ftbisland/commands/JoinIslandCommand.java
@@ -1,7 +1,6 @@
 package com.cricketcraft.ftbisland.commands;
 
 import com.cricketcraft.ftbisland.IslandUtils;
-import ftb.utils.world.LMWorldServer;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
- Modifies the config to allow for multiple island types
- Updates old configs to use the new config Properties, preserving settings from old config Properties
- Adds a single Grass Block as an island type
- Removes unneeded import in JoinIslandCommand

(edit to change terminology from "conifg format")
