### PR TITLE
Add tab completion on /island_join

### DIFF
--- a/src/main/java/com/cricketcraft/ftbisland/commands/JoinIslandCommand.java
+++ b/src/main/java/com/cricketcraft/ftbisland/commands/JoinIslandCommand.java
@@ -39,6 +39,16 @@ public class JoinIslandCommand extends CommandBase implements ICommand {
     public String getCommandUsage(ICommandSender sender) {
         return "island_join <IslandName>";
     }
+    
+    @Override
+    public List addTabCompletionOptions(ICommandSender sender, String[] input) {
+        return input.length == 1 ? getListOfStringsMatchingLastWord(input, getPlayers())
+                : null;
+    }
+
+    protected String[] getPlayers() {
+        return MinecraftServer.getServer().getAllUsernames();
+    }
 
     @Override
     public void processCommand(ICommandSender sender, String[] input) {


### PR DESCRIPTION
Added tab complete for online players island names, personally I would have added tab complete for actual island names but the island_list command is privileged so I decided it would be best not to. However online usernames are not privileged it is easy enough to see whos is online, but typing the name correctly and without capitalisation mistakes, can be more difficult.

Warning this isn't tested I did it from the browser, but it should be fine..
