### PR TITLE
Separate IslandName argument from PlayerName argument

### DIFF
--- a/src/main/java/com/cricketcraft/ftbisland/commands/JoinIslandCommand.java
+++ b/src/main/java/com/cricketcraft/ftbisland/commands/JoinIslandCommand.java
@@ -38,12 +38,12 @@ public class JoinIslandCommand extends CommandBase implements ICommand {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "island_join <IslandName>";
+        return "island_join <IslandName> [PlayerName]";
     }
     
     @Override
     public List addTabCompletionOptions(ICommandSender sender, String[] input) {
-        return input.length == 1 ? getListOfStringsMatchingLastWord(input, getPlayers())
+        return input.length == 2 ? getListOfStringsMatchingLastWord(input, getPlayers())
                 : null;
     }
 
@@ -53,13 +53,16 @@ public class JoinIslandCommand extends CommandBase implements ICommand {
 
     @Override
     public void processCommand(ICommandSender sender, String[] input) {
-        EntityPlayerMP player = getPlayer(sender, input[0]);
-
-        if (input.length == 0) {
-            sender.addChatMessage(new ChatComponentText("Invalid arguments!"));
+        EntityPlayerMP player = null;
+        if (input.length == 1) {
+            player = getCommandSenderAsPlayer(sender);
+        } else if (input.length == 2) {
+            player = getPlayer(sender, input[1]);
         } else {
-            IslandUtils.joinIsland(input[0], player);
+            sender.addChatMessage(new ChatComponentText("Invalid arguments!"));
+            return;
         }
+        IslandUtils.joinIsland(input[0], player);
     }
 
     @Override


### PR DESCRIPTION
Currently, the first argument is used both as the island name and the player name.

This makes usage of the command substantially less flexible, and prevents one of the old use cases for this command (players moving themselves to a group island).

This commit separates out the two arguments to allow for usage with e.g. `@p` in command blocks, but still allow specification of the destination island independent of the player name.

Additionally, while this commit does not do this, it may be a good idea to add a check onto `canCommandSenderUseCommand` for `join_island` to validate that one of the following is true:

* The command sender is an op
* The command sender is a block/other service provider
* The command sender is the same as the player being moved

I didn't implement this part because I'm not sure what you'd actually like here, but I am fairly certain that you don't actually want to use player name and island name as the same parameter.